### PR TITLE
Closes #55: Update Protocol Flow to define required checks for authorization response

### DIFF
--- a/index.html
+++ b/index.html
@@ -496,7 +496,7 @@ sequenceDiagram
 <p>This profile currently assumes that ID Token and a single VP passed as a VP Token are signed by the same Holder DID.</p>
 <p>Note that a Holder DID signing the ID Token in its <code>sub</code> claim is user’s identifier within the RP/Verifier, while a Holder DID signing a VP in its <code>iss</code> claim is user’s identifier within the Issuer, and the two do not have the same connotation.</p>
 <h4 id="span-idtermvalidation-of-authorization-responsevalidation-of-authorization-responsespan"><a class="toc-anchor" href="#span-idtermvalidation-of-authorization-responsevalidation-of-authorization-responsespan" >§</a> <span id="term:validation-of-authorization-response">Validation of Authorization Response</span></h4>
-<p>The following checks MUST be made by the Verifier upon receiving the Authorization Response:</p>
+<p>The following checks MUST be made by the Verifier upon receiving the Authorization Response. Verifiers MAY perform any additional checks according to their trust framework/policies.</p>
 <h5 id="id-token-validation"><a class="toc-anchor" href="#id-token-validation" >§</a> ID Token Validation</h5>
 <p>To validate the received ID Token, the Verifier MUST do the following:</p>
 <ol>

--- a/index.html
+++ b/index.html
@@ -613,10 +613,18 @@ sequenceDiagram
 <h5 id="vp-token-validation"><a class="toc-anchor" href="#vp-token-validation" >§</a> VP Token Validation</h5>
 <p>To Validate the VP Token received, the Verifier MUST do the following:</p>
 <ol>
-<li>The signature on the VP Token MUST be validated. Validation is performed against the key obtained from a DID Document. DID Document MUST be obtained by resolving a Decentralized Identifier included in the <code>sub</code> claim using DID Resolution.</li>
-<li>Using the descriptor map defined the the ID Token, the Verifier MUST obtain the VPs and validate their integrity, authenticity, and holder binding. Inputs should be evaluated using the mechanisms outlined in Section 4.3 of <a class="term-reference" href="#term:presentation-exchange-v1.0.0">Presentation Exchange v1.0.0</a>.</li>
-<li>The Verifier MUST check the revocation status of the VCs embedded in the VPs by discovering the relevant Status List using either DID Relative URLs stored in an HTTPS URL or ID Hubs.</li>
-<li>The integrity of the Issuer of the VC should be checked to confirm that the Issuer controls the DID and its origin. To do so, obtain the Well Known DID Configuration of the Issuer by resolving its DID and then its Linked Domain.</li>
+<li>
+<p>The signature on the VP Token MUST be validated. Validation is performed against the key obtained from a DID Document. DID Document MUST be obtained by resolving a Decentralized Identifier included in the <code>sub</code> claim using DID Resolution.</p>
+</li>
+<li>
+<p>Using the descriptor map defined the the ID Token, the Verifier MUST obtain the VPs and validate their integrity, authenticity, and holder binding. Inputs should be evaluated using the mechanisms outlined in Section 4.3 of <a class="term-reference" href="#term:presentation-exchange-v1.0.0">Presentation Exchange v1.0.0</a>.</p>
+</li>
+<li>
+<p>The revocation status of the VCs embedded in the VPs MUST match those requested in the Presentation Definition of the Authorization Request. The Verifier MUST check the expected status by discovering the relevant Status List using either DID Relative URLs stored in an HTTPS URL or ID Hubs.</p>
+</li>
+<li>
+<p>The integrity of the Issuer of the VC should be checked to confirm that the Issuer controls the DID and its origin. To do so, obtain the Well Known DID Configuration of the Issuer by resolving its DID and then its Linked Domain.</p>
+</li>
 </ol>
 <h3 id="decentralized-identifiers"><a class="toc-anchor" href="#decentralized-identifiers" >§</a> Decentralized Identifiers</h3>
 <p>This profile utilizes Decentralized Identifiers (DIDs) as a cryptographically verifiable identifier of the Verifier/RP and Self-Issued OP and that resolve to cryptographic key material.</p>

--- a/index.html
+++ b/index.html
@@ -179,7 +179,7 @@ sequenceDiagram
   siop ->> siop: Obtains `request_uri`<br> from QR Code
 </div>
 <p>Upon receiving the Request Object, the Wallet will identify VCs that satisfy the Presentation Definition and encapsulate them in a Verifiable Presentation (VP). The Wallet will complete the SIOP or Authorization Response by sending an ID Token and a VP Token to the Verifier’s <code>redirect_uri</code>.</p>
-<p>Upon receiving the ID Token and VP Token, Verifier performs necessary checks as described in the section <a class="term-reference" href="#term:authorization-response-validation">Authorization Response Validation</a> and sends an acknowledgement of receipt back to the Wallet as a 200 HTTP response status code. The flow of the Wallet presenting VCs to the Verifier is now complete.</p>
+<p>Upon receiving the ID Token and VP Token, Verifier performs necessary checks as described in the section <a class="term-reference" href="#term:validation-of-authorization-response">Validation of Authorization Response</a> and sends an acknowledgement of receipt back to the Wallet as a 200 HTTP response status code. The flow of the Wallet presenting VCs to the Verifier is now complete.</p>
 <div class="mermaid">
 sequenceDiagram
   participant user as End User
@@ -484,7 +484,7 @@ sequenceDiagram
 <h3 id="authorization-response"><a class="toc-anchor" href="#authorization-response" >§</a> Authorization Response</h3>
 <p>Authorization Response is sent as an HTTPS POST request to the RP’s endpoint indicated in <code>redirect_uri</code> in the request.</p>
 <p>Note that when this response_mode is used, the user will finish the transaction on the device with a Self-Issued OP, which is a different device than on which the user initiated a request. It is up to the implementations to enable further user interaction with the Verifier/RP on the device used to initiate the request.</p>
-<h3 id="structure-of-authentication-response"><a class="toc-anchor" href="#structure-of-authentication-response" >§</a> Structure of Authentication Response</h3>
+<h3 id="structure-of-authorization-response"><a class="toc-anchor" href="#structure-of-authorization-response" >§</a> Structure of Authorization Response</h3>
 <p>Since requested VCs are returned in a VP Token, two artifacts MUST be returned:</p>
 <ol>
 <li>ID Token that serves as an authentication receipt and includes metadata about the VP Token</li>
@@ -495,6 +495,29 @@ sequenceDiagram
 <p>Note that when in the future use-cases multiple VPs are included in the VP Token, VP Token itself is not signed, and each VP included inside the VP Token MUST be signed.</p>
 <p>This profile currently assumes that ID Token and a single VP passed as a VP Token are signed by the same Holder DID.</p>
 <p>Note that a Holder DID signing the ID Token in its <code>sub</code> claim is user’s identifier within the RP/Verifier, while a Holder DID signing a VP in its <code>iss</code> claim is user’s identifier within the Issuer, and the two do not have the same connotation.</p>
+<h4 id="span-idtermvalidation-of-authorization-responsevalidation-of-authorization-responsespan"><a class="toc-anchor" href="#span-idtermvalidation-of-authorization-responsevalidation-of-authorization-responsespan" >§</a> <span id="term:validation-of-authorization-response">Validation of Authorization Response</span></h4>
+<p>The following checks MUST be made by the Verifier upon receiving the Authorization Response:</p>
+<h5 id="id-token-validation"><a class="toc-anchor" href="#id-token-validation" >§</a> ID Token Validation</h5>
+<p>To validate the received ID Token, the Verifier MUST do the following:</p>
+<ol>
+<li>The Verifier MUST validate ID Token according to the rules defined in section 12.1 of <a class="term-reference" href="#term:siopv2-id1">SIOPv2 ID1</a>.</li>
+<li>The ID Token MUST be signed by the End-User’s DID.</li>
+<li><code>iss</code> claim MUST be <code>https://self-issued.me/v2/openid-vc</code>.</li>
+<li>The signature on the ID Token MUST be validated. Validation is performed against the key obtained from a DID Document. DID Document MUST be obtained by resolving a Decentralized Identifier included in the <code>sub</code> claim using DID Resolution. If a DID Doc contains multiple keys, kid in the header is used to identify which key to use.</li>
+<li>The DID in the <code>kid</code> and <code>sub</code> claim MUST match.</li>
+<li><code>sub</code> claim MUST equal the <code>id</code> property in the DID Document.</li>
+<li>The <code>_vp_token</code> claim MUST be present and contain a presentation_submission with a valid descriptor map.</li>
+</ol>
+<h5 id="vp-token-validation"><a class="toc-anchor" href="#vp-token-validation" >§</a> VP Token Validation</h5>
+<p>To Validate the VP Token received, the Verifier MUST do the following:</p>
+<ol>
+<li>The signature on the VP Token MUST be validated. Validation is performed against the key obtained from a DID Document. DID Document MUST be obtained by resolving a Decentralized Identifier included in the <code>sub</code> claim using DID Resolution. If a DID Doc contains multiple keys, kid in the header is used to identify which key to use.</li>
+<li>The DID in the <code>kid</code> and <code>sub</code> claim MUST match.</li>
+<li>Using the descriptor map obtained from the ID Token, the Verifier MUST determine the number of VPs returned in the VP Token and identify the in which VP requested VC(s) are included.</li>
+<li>Using the presentation definition from the Authorization Request, the Verifier must confirm that the VC meets all requested criteria using the mechanisms outlined in Section 4.3 of <a class="term-reference" href="#term:presentation-exchange-v1.0.0">Presentation Exchange v1.0.0</a>.</li>
+<li>The signature on the VCs embedded in the VPs must be validated.</li>
+<li>It is highly recommened that the Verifier permforms Linked Domain Verification of the Issuer’s DID as defined in <a class="term-reference" href="#term:linked-domain-verification">Linked Domain Verification</a>.</li>
+</ol>
 <h4 id="id-token-example"><a class="toc-anchor" href="#id-token-example" >§</a> ID Token example</h4>
 <p>Below is a non-normative example of an ID Token:</p>
 <div id="id-token" class="notice example"><a class="notice-link" href="#id-token">EXAMPLE</a><pre class="language-json"><code class="language-json"><span class="token punctuation">{</span>
@@ -598,34 +621,6 @@ sequenceDiagram
   <span class="token punctuation">}</span>.<span class="token punctuation">[</span>Signature<span class="token punctuation">]</span>
 </code></pre>
 </div>
-<h4 id="span-idtermauthorization-response-validationauthorization-response-validationspan"><a class="toc-anchor" href="#span-idtermauthorization-response-validationauthorization-response-validationspan" >§</a> <span id="term:authorization-response-validation">Authorization Response Validation</span></h4>
-<p>The following checks MUST be made by the Verifier upon receiving the Authorization Response:</p>
-<h5 id="id-token-validation"><a class="toc-anchor" href="#id-token-validation" >§</a> ID Token Validation</h5>
-<p>To validate the received ID Token, the Verifier MUST do the following:</p>
-<ol>
-<li>The Verifier MUST validate ID Token according to the rules defined in section 12.1 of <a class="term-reference" href="#term:siopv2-id1">SIOPv2 ID1</a>.</li>
-<li>The ID Token MUST be signed by the End-User’s DID.</li>
-<li><code>iss</code> claim MUST be <code>https://self-issued.me/v2/openid-vc</code>.</li>
-<li>The signature on the ID Token MUST be validated. Validation is performed against the key obtained from a DID Document. DID Document MUST be obtained by resolving a Decentralized Identifier included in the <code>sub</code> claim using DID Resolution.</li>
-<li><code>sub</code> claim MUST equal the <code>id</code> property in the DID Document.</li>
-<li>The <code>_vp_token</code> claim MUST be present and contain a presentation_submission with a valid descriptor map.</li>
-</ol>
-<h5 id="vp-token-validation"><a class="toc-anchor" href="#vp-token-validation" >§</a> VP Token Validation</h5>
-<p>To Validate the VP Token received, the Verifier MUST do the following:</p>
-<ol>
-<li>
-<p>The signature on the VP Token MUST be validated. Validation is performed against the key obtained from a DID Document. DID Document MUST be obtained by resolving a Decentralized Identifier included in the <code>sub</code> claim using DID Resolution.</p>
-</li>
-<li>
-<p>Using the descriptor map obtained from the ID Token, the Verifier MUST determine the number of VPs returned in the VP Token and identify the in which VP requested VC(s) are included. Inputs should be evaluated using the mechanisms outlined in Section 4.3 of <a class="term-reference" href="#term:presentation-exchange-v1.0.0">Presentation Exchange v1.0.0</a>.</p>
-</li>
-<li>
-<p>The revocation status of the VCs embedded in the VPs MUST match those requested in the Presentation Definition of the Authorization Request. The Verifier MUST check the expected status by discovering the relevant Status List using either DID Relative URLs stored in an HTTPS URL or ID Hubs.</p>
-</li>
-<li>
-<p>The integrity of the Issuer of the VC should be checked to confirm that the Issuer controls the DID and its origin. To do so, obtain the Well Known DID Configuration of the Issuer by resolving its DID and then its Linked Domain.</p>
-</li>
-</ol>
 <h3 id="decentralized-identifiers"><a class="toc-anchor" href="#decentralized-identifiers" >§</a> Decentralized Identifiers</h3>
 <p>This profile utilizes Decentralized Identifiers (DIDs) as a cryptographically verifiable identifier of the Verifier/RP and Self-Issued OP and that resolve to cryptographic key material.</p>
 <p>ION DIDs can operate in both long-form and short-form. Implementations of this profile MUST be able to consume both long-form and short-form DIDs regardless of whether they are anchored.</p>
@@ -961,11 +956,11 @@ For reference and more information on LD signature suites see the <a path-0="w3c
 </li>
 <li><a href="#end-user-consent" >End-user Consent</a></li>
 <li><a href="#authorization-response" >Authorization Response</a></li>
-<li><a href="#structure-of-authentication-response" >Structure of Authentication Response</a>
+<li><a href="#structure-of-authorization-response" >Structure of Authorization Response</a>
 <ul>
+<li><span id="term:validation-of-authorization-response">Validation of Authorization Response</span>](#span-idtermvalidation-of-authorization-responsevalidation-of-authorization-responsespan)</li>
 <li><a href="#id-token-example" >ID Token example</a></li>
 <li><a href="#vp-token-example" >VP Token example</a></li>
-<li><span id="term:authorization-response-validation">Authorization Response Validation</span>](#span-idtermauthorization-response-validationauthorization-response-validationspan)</li>
 </ul>
 </li>
 <li><a href="#decentralized-identifiers" >Decentralized Identifiers</a>

--- a/index.html
+++ b/index.html
@@ -179,7 +179,7 @@ sequenceDiagram
   siop ->> siop: Obtains `request_uri`<br> from QR Code
 </div>
 <p>Upon receiving the Request Object, the Wallet will identify VCs that satisfy the Presentation Definition and encapsulate them in a Verifiable Presentation (VP). The Wallet will complete the SIOP or Authorization Response by sending an ID Token and a VP Token to the Verifier’s <code>redirect_uri</code>.</p>
-<p>Upon receiving the ID Token and VP Token, Verifier performs necessary checks such as DID resolution, signature validation, Linked Domain validation, revocation checks, etc. and sends an acknowledgement of receipt back to the Wallet. The flow of the Wallet presenting VCs to the Verifier is now complete.</p>
+<p>Upon receiving the ID Token and VP Token, Verifier performs necessary checks as described in the section <a class="term-reference" href="#term:authentication-response-validation">Authentication Response Validation</a> and sends an acknowledgement of receipt back to the Wallet as a 200 HTTP response status code. The flow of the Wallet presenting VCs to the Verifier is now complete.</p>
 <div class="mermaid">
 sequenceDiagram
   participant user as End User
@@ -495,17 +495,6 @@ sequenceDiagram
 <p>Note that when in the future use-cases multiple VPs are included in the VP Token, VP Token itself is not signed, and each VP included inside the VP Token MUST be signed.</p>
 <p>This profile currently assumes that ID Token and a single VP passed as a VP Token are signed by the same Holder DID.</p>
 <p>Note that a Holder DID signing the ID Token in its <code>sub</code> claim is user’s identifier within the RP/Verifier, while a Holder DID signing a VP in its <code>iss</code> claim is user’s identifier within the Issuer, and the two do not have the same connotation.</p>
-<h4 id="id-token-validation"><a class="toc-anchor" href="#id-token-validation" >§</a> ID Token Validation</h4>
-<p>ID Token validation rules defined in section 10 of <a class="term-reference" href="#term:siopv2-id1">SIOPv2 ID1</a> MUST be followed. The ID Token MUST be signed by the End-User’s DID.</p>
-<ul>
-<li><code>iss</code> claim MUST be <code>https://self-issued.me/v2/openid-vc</code>.</li>
-<li>Signature on the ID Token MUST be validated.
-<ul>
-<li>Validation is performed against the key obtained from a DID Document. DID Document MUST be obtained by resolving a Decentralized Identifier included in the <code>sub</code> claim using DID Resolution.</li>
-</ul>
-</li>
-<li><code>sub</code> claim MUST equal the <code>id</code> property in the DID Document.</li>
-</ul>
 <h4 id="id-token-example"><a class="toc-anchor" href="#id-token-example" >§</a> ID Token example</h4>
 <p>Below is a non-normative example of an ID Token:</p>
 <div id="id-token" class="notice example"><a class="notice-link" href="#id-token">EXAMPLE</a><pre class="language-json"><code class="language-json"><span class="token punctuation">{</span>
@@ -609,6 +598,26 @@ sequenceDiagram
   <span class="token punctuation">}</span>.<span class="token punctuation">[</span>Signature<span class="token punctuation">]</span>
 </code></pre>
 </div>
+<h4 id="span-idtermauthentication-response-validationauthentication-response-validationspan"><a class="toc-anchor" href="#span-idtermauthentication-response-validationauthentication-response-validationspan" >§</a> <span id="term:authentication-response-validation">Authentication Response Validation</span></h4>
+<p>The following checks MUST be made by the Verifier upon receiving the Authorization Response:</p>
+<h5 id="id-token-validation"><a class="toc-anchor" href="#id-token-validation" >§</a> ID Token Validation</h5>
+<p>To validate the ID Token received, the Verifier MUST do the following:</p>
+<ol>
+<li>The Verifier MUST validate ID Token according to the rules defined in section 12.1 of <a class="term-reference" href="#term:siopv2-id1">SIOPv2 ID1</a>.</li>
+<li>The ID Token MUST be signed by the End-User’s DID:</li>
+<li><code>iss</code> claim MUST be <code>https://self-issued.me/v2/openid-vc</code>.</li>
+<li>The signature on the ID Token MUST be validated. Validation is performed against the key obtained from a DID Document. DID Document MUST be obtained by resolving a Decentralized Identifier included in the <code>sub</code> claim using DID Resolution.</li>
+<li><code>sub</code> claim MUST equal the <code>id</code> property in the DID Document.</li>
+<li>The <code>_vp_token</code> claim MUST be present and contain a presentation_submission with a valid descriptor map.</li>
+</ol>
+<h5 id="vp-token-validation"><a class="toc-anchor" href="#vp-token-validation" >§</a> VP Token Validation</h5>
+<p>To Validate the VP Token received, the Verifier MUST do the following:</p>
+<ol>
+<li>The signature on the VP Token MUST be validated. Validation is performed against the key obtained from a DID Document. DID Document MUST be obtained by resolving a Decentralized Identifier included in the <code>sub</code> claim using DID Resolution.</li>
+<li>Using the descriptor map defined the the ID Token, the Verifier MUST obtain the VPs and validate their integrity, authenticity, and holder binding. Inputs should be evaluated using the mechanisms outlined in Section 4.3 of <a class="term-reference" href="#term:presentation-exchange-v1.0.0">Presentation Exchange v1.0.0</a>.</li>
+<li>The Verifier MUST check the revocation status of the VCs embedded in the VPs by discovering the relevant Status List using either DID Relative URLs stored in an HTTPS URL or ID Hubs.</li>
+<li>The integrity of the Issuer of the VC should be checked to confirm that the Issuer controls the DID and its origin. To do so, obtain the Well Known DID Configuration of the Issuer by resolving its DID and then its Linked Domain.</li>
+</ol>
 <h3 id="decentralized-identifiers"><a class="toc-anchor" href="#decentralized-identifiers" >§</a> Decentralized Identifiers</h3>
 <p>This profile utilizes Decentralized Identifiers (DIDs) as a cryptographically verifiable identifier of the Verifier/RP and Self-Issued OP and that resolve to cryptographic key material.</p>
 <p>ION DIDs can operate in both long-form and short-form. Implementations of this profile MUST be able to consume both long-form and short-form DIDs regardless of whether they are anchored.</p>
@@ -946,9 +955,9 @@ For reference and more information on LD signature suites see the <a path-0="w3c
 <li><a href="#authorization-response" >Authorization Response</a></li>
 <li><a href="#structure-of-authentication-response" >Structure of Authentication Response</a>
 <ul>
-<li><a href="#id-token-validation" >ID Token Validation</a></li>
 <li><a href="#id-token-example" >ID Token example</a></li>
 <li><a href="#vp-token-example" >VP Token example</a></li>
+<li><span id="term:authentication-response-validation">Authentication Response Validation</span>](#span-idtermauthentication-response-validationauthentication-response-validationspan)</li>
 </ul>
 </li>
 <li><a href="#decentralized-identifiers" >Decentralized Identifiers</a>

--- a/index.html
+++ b/index.html
@@ -179,7 +179,7 @@ sequenceDiagram
   siop ->> siop: Obtains `request_uri`<br> from QR Code
 </div>
 <p>Upon receiving the Request Object, the Wallet will identify VCs that satisfy the Presentation Definition and encapsulate them in a Verifiable Presentation (VP). The Wallet will complete the SIOP or Authorization Response by sending an ID Token and a VP Token to the Verifier’s <code>redirect_uri</code>.</p>
-<p>Upon receiving the ID Token and VP Token, Verifier performs necessary checks as described in the section <a class="term-reference" href="#term:authentication-response-validation">Authentication Response Validation</a> and sends an acknowledgement of receipt back to the Wallet as a 200 HTTP response status code. The flow of the Wallet presenting VCs to the Verifier is now complete.</p>
+<p>Upon receiving the ID Token and VP Token, Verifier performs necessary checks as described in the section <a class="term-reference" href="#term:authorization-response-validation">Authorization Response Validation</a> and sends an acknowledgement of receipt back to the Wallet as a 200 HTTP response status code. The flow of the Wallet presenting VCs to the Verifier is now complete.</p>
 <div class="mermaid">
 sequenceDiagram
   participant user as End User
@@ -598,13 +598,13 @@ sequenceDiagram
   <span class="token punctuation">}</span>.<span class="token punctuation">[</span>Signature<span class="token punctuation">]</span>
 </code></pre>
 </div>
-<h4 id="span-idtermauthentication-response-validationauthentication-response-validationspan"><a class="toc-anchor" href="#span-idtermauthentication-response-validationauthentication-response-validationspan" >§</a> <span id="term:authentication-response-validation">Authentication Response Validation</span></h4>
+<h4 id="span-idtermauthorization-response-validationauthorization-response-validationspan"><a class="toc-anchor" href="#span-idtermauthorization-response-validationauthorization-response-validationspan" >§</a> <span id="term:authorization-response-validation">Authorization Response Validation</span></h4>
 <p>The following checks MUST be made by the Verifier upon receiving the Authorization Response:</p>
 <h5 id="id-token-validation"><a class="toc-anchor" href="#id-token-validation" >§</a> ID Token Validation</h5>
-<p>To validate the ID Token received, the Verifier MUST do the following:</p>
+<p>To validate the received ID Token, the Verifier MUST do the following:</p>
 <ol>
 <li>The Verifier MUST validate ID Token according to the rules defined in section 12.1 of <a class="term-reference" href="#term:siopv2-id1">SIOPv2 ID1</a>.</li>
-<li>The ID Token MUST be signed by the End-User’s DID:</li>
+<li>The ID Token MUST be signed by the End-User’s DID.</li>
 <li><code>iss</code> claim MUST be <code>https://self-issued.me/v2/openid-vc</code>.</li>
 <li>The signature on the ID Token MUST be validated. Validation is performed against the key obtained from a DID Document. DID Document MUST be obtained by resolving a Decentralized Identifier included in the <code>sub</code> claim using DID Resolution.</li>
 <li><code>sub</code> claim MUST equal the <code>id</code> property in the DID Document.</li>
@@ -617,7 +617,7 @@ sequenceDiagram
 <p>The signature on the VP Token MUST be validated. Validation is performed against the key obtained from a DID Document. DID Document MUST be obtained by resolving a Decentralized Identifier included in the <code>sub</code> claim using DID Resolution.</p>
 </li>
 <li>
-<p>Using the descriptor map defined the the ID Token, the Verifier MUST obtain the VPs and validate their integrity, authenticity, and holder binding. Inputs should be evaluated using the mechanisms outlined in Section 4.3 of <a class="term-reference" href="#term:presentation-exchange-v1.0.0">Presentation Exchange v1.0.0</a>.</p>
+<p>Using the descriptor map obtained from the ID Token, the Verifier MUST determine the number of VPs returned in the VP Token and identify the in which VP requested VC(s) are included. Inputs should be evaluated using the mechanisms outlined in Section 4.3 of <a class="term-reference" href="#term:presentation-exchange-v1.0.0">Presentation Exchange v1.0.0</a>.</p>
 </li>
 <li>
 <p>The revocation status of the VCs embedded in the VPs MUST match those requested in the Presentation Definition of the Authorization Request. The Verifier MUST check the expected status by discovering the relevant Status List using either DID Relative URLs stored in an HTTPS URL or ID Hubs.</p>
@@ -965,7 +965,7 @@ For reference and more information on LD signature suites see the <a path-0="w3c
 <ul>
 <li><a href="#id-token-example" >ID Token example</a></li>
 <li><a href="#vp-token-example" >VP Token example</a></li>
-<li><span id="term:authentication-response-validation">Authentication Response Validation</span>](#span-idtermauthentication-response-validationauthentication-response-validationspan)</li>
+<li><span id="term:authorization-response-validation">Authorization Response Validation</span>](#span-idtermauthorization-response-validationauthorization-response-validationspan)</li>
 </ul>
 </li>
 <li><a href="#decentralized-identifiers" >Decentralized Identifiers</a>

--- a/spec/spec.md
+++ b/spec/spec.md
@@ -511,7 +511,8 @@ To Validate the VP Token received, the Verifier MUST do the following:
 
 1. The signature on the VP Token MUST be validated. Validation is performed against the key obtained from a DID Document. DID Document MUST be obtained by resolving a Decentralized Identifier included in the `sub` claim using DID Resolution.
 2. Using the descriptor map defined the the ID Token, the Verifier MUST obtain the VPs and validate their integrity, authenticity, and holder binding. Inputs should be evaluated using the mechanisms outlined in Section 4.3 of [[ref: Presentation Exchange v1.0.0]].
-3. The Verifier MUST check the revocation status of the VCs embedded in the VPs by discovering the relevant Status List using either DID Relative URLs stored in an HTTPS URL or ID Hubs.
+3. The revocation status of the VCs embedded in the VPs MUST match those requested in the Presentation Definition of the Authorization Request. The Verifier MUST check the expected status by discovering the relevant Status List using either DID Relative URLs stored in an HTTPS URL or ID Hubs.
+
 4. The integrity of the Issuer of the VC should be checked to confirm that the Issuer controls the DID and its origin. To do so, obtain the Well Known DID Configuration of the Issuer by resolving its DID and then its Linked Domain.
 
 ### Decentralized Identifiers

--- a/spec/spec.md
+++ b/spec/spec.md
@@ -468,13 +468,13 @@ Verifiers MUST go through (at least) the following steps and validate ID Token a
 
 ##### VP Token Validation
 
-To Validate the VP Token received, the Verifier MUST do the following:
+Verifiers MUST go through (at least) the following steps before trusting/using any of the contents of a VP Token:
 
-1. The signature on the VP Token MUST be validated. Validation is performed against the key obtained from a DID Document. DID Document MUST be obtained by resolving a Decentralized Identifier included in the `sub` claim using DID Resolution. If a DID Doc contains multiple keys, kid in the header is used to identify which key to use.
-2. The DID in the `kid` and `sub` claim MUST match.
-3. Using the descriptor map obtained from the ID Token, the Verifier MUST determine the number of VPs returned in the VP Token and identify the in which VP requested VC(s) are included.
-4. Using the presentation definition from the Authorization Request, the Verifier must confirm that the VC meets all requested criteria using the mechanisms outlined in Section 4.3 of [[ref: Presentation Exchange v1.0.0]].
-5. The signature on the VCs embedded in the VPs must be validated.
+1. Validate the signature on the VP Token. Validation is performed against the key obtained from a DID Document. DID Document MUST be obtained by resolving a Decentralized Identifier included in the `sub` claim using DID Resolution. If a DID Doc contains multiple keys, kid in the header is used to identify which key to use.
+2. Check that the DID value in the `kid` and `sub` claims match.
+3. Determine the number of VPs returned in the VP Token and identify in which VP requested VC(s) are included, using the descriptor map obtained from the ID Token.
+4. Confirm that the VC meets all requested criteria using the mechanisms outlined in Section 4.3 of [[ref: Presentation Exchange v1.0.0]], using the presentation definition from the Authorization Request.
+5. Validate signature(s) on each VC(s).
 6. It is highly recommened that the Verifier permforms Linked Domain Verification of the Issuer's DID as defined in [[ref: Linked Domain Verification]].
 
 #### ID Token example

--- a/spec/spec.md
+++ b/spec/spec.md
@@ -496,7 +496,7 @@ The following checks MUST be made by the Verifier upon receiving the Authorizati
 
 ##### ID Token Validation
 
-To validate the ID Token received, the Verifier MUST do the following:
+To validate the received ID Token, the Verifier MUST do the following:
 
 1. The Verifier MUST validate ID Token according to the rules defined in section 12.1 of [[ref: SIOPv2 ID1]].
 2. The ID Token MUST be signed by the End-User's DID:

--- a/spec/spec.md
+++ b/spec/spec.md
@@ -477,8 +477,7 @@ Verifiers MUST go through (at least) the following steps before trusting/using a
 5. Check that the DID value in the `kid` and `iss` claims match in each of the VC(s).
 6. Validate signature(s) on each VC(s). Validation is performed against the key obtained from a DID Document. DID Document MUST be obtained by resolving a Decentralized Identifier included in the `iss` claim using DID Resolution. If a DID Doc contains multiple keys, kid in the header is used to identify which key to use.
 7. Check that the DID value in the `iss` Claim of a VP exactly match with the `sub` Claim in the VC(s). (Holder Binding)
-8. It is highly recommended that the Verifier performs Linked Domain Verification of the Issuer's DID using the mechanism defined in [[ref: Linked Domain Verification]].
-9. It is highly recommended that the Verifier checks the status of the VC(s) using the mechanism defined in [[ref: Revocation]].
+8. Perform the checks required by the Verifier's policy, based on the set of trust requirements such as trust frameworks it belongs to. The checks can include Linked Domain verification of the Credential Issuer's DID using the mechanism defined in [[ref: Linked Domain Verification]] and Credential status validation of the VC(s) using the mechanism defined in [[ref: Revocation]].
 
 #### ID Token example
 

--- a/spec/spec.md
+++ b/spec/spec.md
@@ -176,7 +176,7 @@ sequenceDiagram
 
 Upon receiving the Request Object, the Wallet will identify VCs that satisfy the Presentation Definition and encapsulate them in a Verifiable Presentation (VP). The Wallet will complete the SIOP or Authorization Response by sending an ID Token and a VP Token to the Verifier's `redirect_uri`.
 
-Upon receiving the ID Token and VP Token, Verifier performs necessary checks as described in the section [[ref:Authorization Response Validation]] and sends an acknowledgement of receipt back to the Wallet as a 200 HTTP response status code. The flow of the Wallet presenting VCs to the Verifier is now complete.
+Upon receiving the ID Token and VP Token, Verifier performs necessary checks as described in the section [[ref:Validation of Authorization Response]] and sends an acknowledgement of receipt back to the Wallet as a 200 HTTP response status code. The flow of the Wallet presenting VCs to the Verifier is now complete.
 
 ```mermaid
 sequenceDiagram
@@ -434,7 +434,7 @@ Authorization Response is sent as an HTTPS POST request to the RP's endpoint ind
 
 Note that when this response_mode is used, the user will finish the transaction on the device with a Self-Issued OP, which is a different device than on which the user initiated a request. It is up to the implementations to enable further user interaction with the Verifier/RP on the device used to initiate the request.
 
-### Structure of Authentication Response
+### Structure of Authorization Response
 
 Since requested VCs are returned in a VP Token, two artifacts MUST be returned:
 
@@ -450,6 +450,33 @@ Note that when in the future use-cases multiple VPs are included in the VP Token
 This profile currently assumes that ID Token and a single VP passed as a VP Token are signed by the same Holder DID.
 
 Note that a Holder DID signing the ID Token in its `sub` claim is user's identifier within the RP/Verifier, while a Holder DID signing a VP in its `iss` claim is user's identifier within the Issuer, and the two do not have the same connotation.
+
+#### [[def:Validation of Authorization Response]]
+
+The following checks MUST be made by the Verifier upon receiving the Authorization Response:
+
+##### ID Token Validation
+
+To validate the received ID Token, the Verifier MUST do the following:
+
+1. The Verifier MUST validate ID Token according to the rules defined in section 12.1 of [[ref: SIOPv2 ID1]].
+2. The ID Token MUST be signed by the End-User's DID.
+3. `iss` claim MUST be `https://self-issued.me/v2/openid-vc`.
+4. The signature on the ID Token MUST be validated. Validation is performed against the key obtained from a DID Document. DID Document MUST be obtained by resolving a Decentralized Identifier included in the `sub` claim using DID Resolution. If a DID Doc contains multiple keys, kid in the header is used to identify which key to use.
+5. The DID in the `kid` and `sub` claim MUST match.
+6. `sub` claim MUST equal the `id` property in the DID Document.
+7. The `_vp_token` claim MUST be present and contain a presentation_submission with a valid descriptor map.
+
+##### VP Token Validation
+
+To Validate the VP Token received, the Verifier MUST do the following:
+
+1. The signature on the VP Token MUST be validated. Validation is performed against the key obtained from a DID Document. DID Document MUST be obtained by resolving a Decentralized Identifier included in the `sub` claim using DID Resolution. If a DID Doc contains multiple keys, kid in the header is used to identify which key to use.
+2. The DID in the `kid` and `sub` claim MUST match.
+3. Using the descriptor map obtained from the ID Token, the Verifier MUST determine the number of VPs returned in the VP Token and identify the in which VP requested VC(s) are included.
+4. Using the presentation definition from the Authorization Request, the Verifier must confirm that the VC meets all requested criteria using the mechanisms outlined in Section 4.3 of [[ref: Presentation Exchange v1.0.0]].
+5. The signature on the VCs embedded in the VPs must be validated.
+6. It is highly recommened that the Verifier permforms Linked Domain Verification of the Issuer's DID as defined in [[ref: Linked Domain Verification]].
 
 #### ID Token example
 
@@ -489,31 +516,6 @@ Below is a non-normative example of a decoded VC in a JSON format, signed as a J
 [[insert: ./spec/assets/sample_vc_1.json]]
 ```
 :::
-
-#### [[def:Authorization Response Validation]]
-
-The following checks MUST be made by the Verifier upon receiving the Authorization Response:
-
-##### ID Token Validation
-
-To validate the received ID Token, the Verifier MUST do the following:
-
-1. The Verifier MUST validate ID Token according to the rules defined in section 12.1 of [[ref: SIOPv2 ID1]].
-2. The ID Token MUST be signed by the End-User's DID.
-3. `iss` claim MUST be `https://self-issued.me/v2/openid-vc`.
-4. The signature on the ID Token MUST be validated. Validation is performed against the key obtained from a DID Document. DID Document MUST be obtained by resolving a Decentralized Identifier included in the `sub` claim using DID Resolution.
-5. `sub` claim MUST equal the `id` property in the DID Document.
-6. The `_vp_token` claim MUST be present and contain a presentation_submission with a valid descriptor map.
-
-##### VP Token Validation
-
-To Validate the VP Token received, the Verifier MUST do the following:
-
-1. The signature on the VP Token MUST be validated. Validation is performed against the key obtained from a DID Document. DID Document MUST be obtained by resolving a Decentralized Identifier included in the `sub` claim using DID Resolution.
-2. Using the descriptor map obtained from the ID Token, the Verifier MUST determine the number of VPs returned in the VP Token and identify the in which VP requested VC(s) are included. Inputs should be evaluated using the mechanisms outlined in Section 4.3 of [[ref: Presentation Exchange v1.0.0]].
-3. The revocation status of the VCs embedded in the VPs MUST match those requested in the Presentation Definition of the Authorization Request. The Verifier MUST check the expected status by discovering the relevant Status List using either DID Relative URLs stored in an HTTPS URL or ID Hubs.
-
-4. The integrity of the Issuer of the VC should be checked to confirm that the Issuer controls the DID and its origin. To do so, obtain the Well Known DID Configuration of the Issuer by resolving its DID and then its Linked Domain.
 
 ### Decentralized Identifiers
 

--- a/spec/spec.md
+++ b/spec/spec.md
@@ -510,7 +510,7 @@ To validate the received ID Token, the Verifier MUST do the following:
 To Validate the VP Token received, the Verifier MUST do the following:
 
 1. The signature on the VP Token MUST be validated. Validation is performed against the key obtained from a DID Document. DID Document MUST be obtained by resolving a Decentralized Identifier included in the `sub` claim using DID Resolution.
-2. Using the descriptor map defined the the ID Token, the Verifier MUST obtain the VPs and validate their integrity, authenticity, and holder binding. Inputs should be evaluated using the mechanisms outlined in Section 4.3 of [[ref: Presentation Exchange v1.0.0]].
+2. Using the descriptor map obtained from the ID Token, the Verifier MUST determine the number of VPs returned in the VP Token and identify the in which VP requested VC(s) are included. Inputs should be evaluated using the mechanisms outlined in Section 4.3 of [[ref: Presentation Exchange v1.0.0]].
 3. The revocation status of the VCs embedded in the VPs MUST match those requested in the Presentation Definition of the Authorization Request. The Verifier MUST check the expected status by discovering the relevant Status List using either DID Relative URLs stored in an HTTPS URL or ID Hubs.
 
 4. The integrity of the Issuer of the VC should be checked to confirm that the Issuer controls the DID and its origin. To do so, obtain the Well Known DID Configuration of the Issuer by resolving its DID and then its Linked Domain.

--- a/spec/spec.md
+++ b/spec/spec.md
@@ -474,8 +474,8 @@ Verifiers MUST go through (at least) the following steps before trusting/using a
 2. Check that the DID value in the `kid` and `iss` claims match in each of the VP(s).
 3. Validate the signature of each of the VP(s) passed in the VP Token. Validation is performed against the key obtained from a DID Document. DID Document MUST be obtained by resolving a Decentralized Identifier included in the `iss` claim using DID Resolution. If a DID Doc contains multiple keys, kid in the header is used to identify which key to use.
 4. Confirm that the VC meets all requested criteria using the mechanisms outlined in Section 4.3 of [[ref: Presentation Exchange v1.0.0]], using the presentation definition from the Authorization Request.
-5. Validate signature(s) on each VC(s). Validation is performed against the key obtained from a DID Document. DID Document MUST be obtained by resolving a Decentralized Identifier included in the `iss` claim using DID Resolution. If a DID Doc contains multiple keys, kid in the header is used to identify which key to use.
-6. Check that the DID value in the `kid` and `iss` claims match in each of the VC(s).
+5. Check that the DID value in the `kid` and `iss` claims match in each of the VC(s).
+6. Validate signature(s) on each VC(s). Validation is performed against the key obtained from a DID Document. DID Document MUST be obtained by resolving a Decentralized Identifier included in the `iss` claim using DID Resolution. If a DID Doc contains multiple keys, kid in the header is used to identify which key to use.
 7. Check that the DID value in the `iss` Claim of a VP exactly match with the `sub` Claim in the VC(s). (Holder Binding)
 8. It is highly recommended that the Verifier performs Linked Domain Verification of the Issuer's DID as defined in [[ref: Linked Domain Verification]].
 

--- a/spec/spec.md
+++ b/spec/spec.md
@@ -461,21 +461,23 @@ The following checks MUST be made by the Verifier upon receiving the Authorizati
 Verifiers MUST go through (at least) the following steps and validate ID Token according to the rules defined in section 12.1 of [[ref: SIOPv2 ID1]] before trusting/using any of the contents of an ID Token:
 
 1. Ensure that `iss` claim is `https://self-issued.me/v2/openid-vc`.
-2. Validate the signature on the ID Token. Validation is performed against the key obtained from a DID Document. DID Document MUST be obtained by resolving a Decentralized Identifier included in the `sub` claim using DID Resolution. If a DID Doc contains multiple keys, kid in the header is used to identify which key to use.
-3. Check that the DID in the `kid` and `sub` claims exactly match.
-4. Check that `sub` claim equal the `id` property in the DID Document.
+2. Check that the DID value in the `kid` and `sub` claims exactly match.
+3. Validate the signature on the ID Token. Validation is performed against the key obtained from a DID Document. DID Document MUST be obtained by resolving a Decentralized Identifier included in the `sub` claim using DID Resolution. If a DID Doc contains multiple keys, kid in the header is used to identify which key to use.
+4. Check that `sub` claim equal the value of the `id` property in the DID Document obtained in step 3.
 5. Check that the `_vp_token` claim is present and contains a `presentation_submission` with a valid descriptor map.
 
 ##### VP Token Validation
 
 Verifiers MUST go through (at least) the following steps before trusting/using any of the contents of a VP Token:
 
-1. Validate the signature on the VP Token. Validation is performed against the key obtained from a DID Document. DID Document MUST be obtained by resolving a Decentralized Identifier included in the `sub` claim using DID Resolution. If a DID Doc contains multiple keys, kid in the header is used to identify which key to use.
-2. Check that the DID value in the `kid` and `sub` claims match.
-3. Determine the number of VPs returned in the VP Token and identify in which VP requested VC(s) are included, using the descriptor map obtained from the ID Token.
+1. Determine the number of VPs returned in the VP Token and identify in which VP requested VC(s) are included, using the descriptor map obtained from the ID Token.
+2. Check that the DID value in the `kid` and `iss` claims match in each of the VP(s).
+3. Validate the signature of each of the VP(s) passed in the VP Token. Validation is performed against the key obtained from a DID Document. DID Document MUST be obtained by resolving a Decentralized Identifier included in the `iss` claim using DID Resolution. If a DID Doc contains multiple keys, kid in the header is used to identify which key to use.
 4. Confirm that the VC meets all requested criteria using the mechanisms outlined in Section 4.3 of [[ref: Presentation Exchange v1.0.0]], using the presentation definition from the Authorization Request.
-5. Validate signature(s) on each VC(s).
-6. It is highly recommened that the Verifier permforms Linked Domain Verification of the Issuer's DID as defined in [[ref: Linked Domain Verification]].
+5. Validate signature(s) on each VC(s). Validation is performed against the key obtained from a DID Document. DID Document MUST be obtained by resolving a Decentralized Identifier included in the `iss` claim using DID Resolution. If a DID Doc contains multiple keys, kid in the header is used to identify which key to use.
+6. Check that the DID value in the `kid` and `iss` claims match in each of the VC(s).
+7. Check that the DID value in the `iss` Claim of a VP exactly match with the `sub` Claim in the VC(s). (Holder Binding)
+8. It is highly recommended that the Verifier performs Linked Domain Verification of the Issuer's DID as defined in [[ref: Linked Domain Verification]].
 
 #### ID Token example
 

--- a/spec/spec.md
+++ b/spec/spec.md
@@ -499,7 +499,7 @@ The following checks MUST be made by the Verifier upon receiving the Authorizati
 To validate the received ID Token, the Verifier MUST do the following:
 
 1. The Verifier MUST validate ID Token according to the rules defined in section 12.1 of [[ref: SIOPv2 ID1]].
-2. The ID Token MUST be signed by the End-User's DID:
+2. The ID Token MUST be signed by the End-User's DID.
 3. `iss` claim MUST be `https://self-issued.me/v2/openid-vc`.
 4. The signature on the ID Token MUST be validated. Validation is performed against the key obtained from a DID Document. DID Document MUST be obtained by resolving a Decentralized Identifier included in the `sub` claim using DID Resolution.
 5. `sub` claim MUST equal the `id` property in the DID Document.

--- a/spec/spec.md
+++ b/spec/spec.md
@@ -473,11 +473,12 @@ Verifiers MUST go through (at least) the following steps before trusting/using a
 1. Determine the number of VPs returned in the VP Token and identify in which VP requested VC(s) are included, using the descriptor map obtained from the ID Token.
 2. Check that the DID value in the `kid` and `iss` claims match in each of the VP(s).
 3. Validate the signature of each of the VP(s) passed in the VP Token. Validation is performed against the key obtained from a DID Document. DID Document MUST be obtained by resolving a Decentralized Identifier included in the `iss` claim using DID Resolution. If a DID Doc contains multiple keys, kid in the header is used to identify which key to use.
-4. Confirm that the VC meets all requested criteria using the mechanisms outlined in Section 4.3 of [[ref: Presentation Exchange v1.0.0]], using the presentation definition from the Authorization Request.
+4. Confirm that the VC meets all requested criteria using the mechanisms outlined in Section 4.3 of [[ref: Presentation Exchange v1.0.0]], using the presentation definition from the Authorization Request, i.e. credential format, type, JSON schema, etc.
 5. Check that the DID value in the `kid` and `iss` claims match in each of the VC(s).
 6. Validate signature(s) on each VC(s). Validation is performed against the key obtained from a DID Document. DID Document MUST be obtained by resolving a Decentralized Identifier included in the `iss` claim using DID Resolution. If a DID Doc contains multiple keys, kid in the header is used to identify which key to use.
 7. Check that the DID value in the `iss` Claim of a VP exactly match with the `sub` Claim in the VC(s). (Holder Binding)
-8. It is highly recommended that the Verifier performs Linked Domain Verification of the Issuer's DID as defined in [[ref: Linked Domain Verification]].
+8. It is highly recommended that the Verifier performs Linked Domain Verification of the Issuer's DID using the mechanism defined in [[ref: Linked Domain Verification]].
+9. It is highly recommended that the Verifier checks the status of the VC(s) using the mechanism defined in [[ref: Revocation]].
 
 #### ID Token example
 

--- a/spec/spec.md
+++ b/spec/spec.md
@@ -453,7 +453,7 @@ Note that a Holder DID signing the ID Token in its `sub` claim is user's identif
 
 #### [[def:Validation of Authorization Response]]
 
-The following checks MUST be made by the Verifier upon receiving the Authorization Response:
+The following checks MUST be made by the Verifier upon receiving the Authorization Response. Verifiers MAY perform any additional checks according to their trust framework/policies.
 
 ##### ID Token Validation
 

--- a/spec/spec.md
+++ b/spec/spec.md
@@ -457,15 +457,14 @@ The following checks MUST be made by the Verifier upon receiving the Authorizati
 
 ##### ID Token Validation
 
-To validate the received ID Token, the Verifier MUST do the following:
 
-1. The Verifier MUST validate ID Token according to the rules defined in section 12.1 of [[ref: SIOPv2 ID1]].
-2. The ID Token MUST be signed by the End-User's DID.
-3. `iss` claim MUST be `https://self-issued.me/v2/openid-vc`.
-4. The signature on the ID Token MUST be validated. Validation is performed against the key obtained from a DID Document. DID Document MUST be obtained by resolving a Decentralized Identifier included in the `sub` claim using DID Resolution. If a DID Doc contains multiple keys, kid in the header is used to identify which key to use.
-5. The DID in the `kid` and `sub` claim MUST match.
-6. `sub` claim MUST equal the `id` property in the DID Document.
-7. The `_vp_token` claim MUST be present and contain a presentation_submission with a valid descriptor map.
+Verifiers MUST go through (at least) the following steps and validate ID Token according to the rules defined in section 12.1 of [[ref: SIOPv2 ID1]] before trusting/using any of the contents of an ID Token:
+
+1. Ensure that `iss` claim is `https://self-issued.me/v2/openid-vc`.
+2. Validate the signature on the ID Token. Validation is performed against the key obtained from a DID Document. DID Document MUST be obtained by resolving a Decentralized Identifier included in the `sub` claim using DID Resolution. If a DID Doc contains multiple keys, kid in the header is used to identify which key to use.
+3. Check that the DID in the `kid` and `sub` claims exactly match.
+4. Check that `sub` claim equal the `id` property in the DID Document.
+5. Check that the `_vp_token` claim is present and contains a `presentation_submission` with a valid descriptor map.
 
 ##### VP Token Validation
 

--- a/spec/spec.md
+++ b/spec/spec.md
@@ -176,7 +176,7 @@ sequenceDiagram
 
 Upon receiving the Request Object, the Wallet will identify VCs that satisfy the Presentation Definition and encapsulate them in a Verifiable Presentation (VP). The Wallet will complete the SIOP or Authorization Response by sending an ID Token and a VP Token to the Verifier's `redirect_uri`.
 
-Upon receiving the ID Token and VP Token, Verifier performs necessary checks as described in the section [[ref:Authentication Response Validation]] and sends an acknowledgement of receipt back to the Wallet as a 200 HTTP response status code. The flow of the Wallet presenting VCs to the Verifier is now complete.
+Upon receiving the ID Token and VP Token, Verifier performs necessary checks as described in the section [[ref:Authorization Response Validation]] and sends an acknowledgement of receipt back to the Wallet as a 200 HTTP response status code. The flow of the Wallet presenting VCs to the Verifier is now complete.
 
 ```mermaid
 sequenceDiagram
@@ -490,7 +490,7 @@ Below is a non-normative example of a decoded VC in a JSON format, signed as a J
 ```
 :::
 
-#### [[def:Authentication Response Validation]]
+#### [[def:Authorization Response Validation]]
 
 The following checks MUST be made by the Verifier upon receiving the Authorization Response:
 


### PR DESCRIPTION
This PR closes #55 

It revises the language in the protocol flow to be precise about required checks for the id and vp token. I've moved the checks out into their own section and refer to it in the protocol flow.