### PR TITLE
Fixing versioning link

### DIFF
--- a/specs.json
+++ b/specs.json
@@ -20,7 +20,7 @@
     {
       "title": "JWT VC Presentation Profile",
       "spec_directory": "./spec/v0.0.1/",
-      "output_path": "./build/spec/v0.0.1",
+      "output_path": "./spec/v0.0.1",
       "logo": "https://rawcdn.githack.com/decentralized-identity/decentralized-identity.github.io/a3ca39717e440302d1fd99a796e7f00e1c42eb2d/images/logo-flat.svg",
       "logo_link": "https://github.com/decentralized-identity/jwt-vc-presentation-profile",
       "source": {

--- a/specs.json
+++ b/specs.json
@@ -3,7 +3,7 @@
     {
       "title": "JWT VC Presentation Profile",
       "spec_directory": "./spec",
-      "output_path": "./",
+      "output_path": "./build",
       "logo": "logo.svg",
       "logo_link": "https://github.com/decentralized-identity/jwt-vc-presentation-profile",
       "source": {
@@ -19,8 +19,8 @@
     },
     {
       "title": "JWT VC Presentation Profile",
-      "spec_directory": "./spec/v0.0.1/",
-      "output_path": "./spec/v0.0.1",
+      "spec_directory": "./spec/v0.0.1",
+      "output_path": "./build/spec/v0.0.1",
       "logo": "https://rawcdn.githack.com/decentralized-identity/decentralized-identity.github.io/a3ca39717e440302d1fd99a796e7f00e1c42eb2d/images/logo-flat.svg",
       "logo_link": "https://github.com/decentralized-identity/jwt-vc-presentation-profile",
       "source": {


### PR DESCRIPTION
Update the spec file to publish both in build dir and removed trailing `/`. 

<img width="1437" alt="image" src="https://github.com/decentralized-identity/jwt-vc-presentation-profile/assets/8604639/b04ccce5-fc3b-4cae-a6c9-6e5ffd352df6">

Seems to work on my end, but not quite sure why it wasn't working before. 

I won't be able to confirm until we've merged it, or Paul Grehan might be able to double check. 
